### PR TITLE
New Scene now clears out all of bridgeworks.

### DIFF
--- a/public/js/Bridgeworks.js
+++ b/public/js/Bridgeworks.js
@@ -26618,6 +26618,7 @@ Bridgeworks.prototype.onLoadModified = function()
 
     this.commandMgr.clearCommandSequence();
     this.eventMgr.clearEvents();
+    $('#RasterComponents').empty();
     //this.resouceMgr.clear(); There is no resourceMgr in javascript version
     this.selector.clearSelections();
     this.selector.getAttribute("lastSelectedName").setValueDirect("");


### PR DESCRIPTION
The labels now will clear themselves when New Scene is called. The way labels were being added was different than how you did it in the C++ version. You were appended children onto a already made Element called "RasterComponent" I just ran a .empty() on this component which clears all of its children but leaves the main element. This will give us the desire effect of our New Scene
