### PR TITLE
Right clicking another object...

### DIFF
--- a/public/js/contextmenu.js
+++ b/public/js/contextmenu.js
@@ -3,9 +3,12 @@
 document.addEventListener('contextmenu', function(e) {
 
     selectObject();
+    var isActive = $("#model-menu").hasClass("active");
     if (g_selectedModel) {
       positionMenu(e, modelMenu);
-      $("#model-menu").toggleClass("active");
+      if (!isActive){
+        $("#model-menu").toggleClass("active");
+      }
     }
 
     e.preventDefault();


### PR DESCRIPTION
...while the context menu is open now moves the context menu to the new object.
The menu now just moves, without animating, to the new object. I found that retaining animation made the experience clunky.