### PR TITLE
fixes jumpy bottom bar on hover in FireFox 

### DIFF
--- a/public/css/actionsbar.css
+++ b/public/css/actionsbar.css
@@ -201,8 +201,6 @@ button.parts-btn {
   box-shadow: 0px 0px 1px 3px rgba(0,0,0,1);
   background: rgba(0,0,0,0.6);
   width: 100%;
-  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
-          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
   -webkit-animation: Close-Bottom-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 10s;
      -moz-animation: Close-Bottom-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 10s;
        -o-animation: Close-Bottom-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 10s;
@@ -212,7 +210,6 @@ button.parts-btn {
 /*-- Actions Bar Column --*/
 
 .palette {
-  position: relative;
   bottom: 0;
   width: 90%;
   margin: 0 auto;


### PR DESCRIPTION
...by removing position:relative on palette class, and transition all on actions-bar. Tested in Chrome, Safari, and FF. 