### PR TITLE
Delay drawer close by 45 sec after mouseout

### DIFF
--- a/public/css/actionsbar.css
+++ b/public/css/actionsbar.css
@@ -35,8 +35,8 @@
 
 .parts-bar {
   position: relative;
-  -webkit-transition: margin-top 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
-          transition: margin-top 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+  -webkit-transition: margin-top 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
+          transition: margin-top 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
   -webkit-animation: Close-Top-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 3s;
      -moz-animation: Close-Top-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 3s;
        -o-animation: Close-Top-Drawer 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) forwards 3s;
@@ -65,8 +65,8 @@
 .nav-menu {
   position: relative;
   top: 0;
-  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
-          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
+          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
 }
 
 
@@ -216,8 +216,8 @@ button.parts-btn {
   height: 100px;
   overflow-y: hidden;
   overflow-x: scroll;
-  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
-          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
+          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94) 45s;
 }
 
 /*-- Actions Bar List --*/
@@ -399,6 +399,8 @@ li.action {
   bottom: 150px;
   background: rgba(0,0,0,0.6);
   box-shadow: 0px 0px 1px 3px rgba(0,0,0,1);
+  -webkit-transition: bottom 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+          transition: bottom 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
 }
 
 .navbar-fixed-bottom.hover:hover .scroll-left,
@@ -406,6 +408,8 @@ li.action {
   -webkit-transform: translate(0px,-150px);
       -ms-transform: translate(0px,-150px);
           transform: translate(0px,-150px);
+  -webkit-transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+          transition: all 400ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
 }
 
 
@@ -413,6 +417,8 @@ li.action {
 .navbar-fixed-top.hover:hover .parts,
 .navbar-fixed-top.hover:hover .nav-menu {
     top: 100px;
+  -webkit-transition: top 400ms ease;
+          transition: top 400ms ease;
 }
 
 


### PR DESCRIPTION
Uses CSS transition-delay property on the original states of the selected elements to delay the transition from hover to original state by 45 seconds. 